### PR TITLE
Explicitly include placeholders and QPainterPath (fixes build failure)

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -25,6 +25,10 @@
 #include <QDebug>
 #include <QTimer>
 
+#include <boost/bind/placeholders.hpp>
+
+using namespace boost::placeholders;
+
 class CBlockIndex;
 
 static int64_t nLastHeaderTipUpdateNotification = 0;

--- a/src/qt/drivechaingui.cpp
+++ b/src/qt/drivechaingui.cpp
@@ -76,6 +76,10 @@ const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #endif
         ;
 
+#include <boost/bind/placeholders.hpp>
+
+using namespace boost::placeholders;
+
 /** Display name for default wallet name. Uses tilde to avoid name
  * collisions in the future with additional wallets */
 const QString BitcoinGUI::DEFAULT_WALLET = "~Default";

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -26,6 +26,10 @@
 #include <QPainter>
 #include <QRadialGradient>
 
+#include <boost/bind/placeholders.hpp>
+
+using namespace boost::placeholders;
+
 SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) :
     QWidget(0, f), curAlignment(0)
 {

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -5,6 +5,7 @@
 #include <qt/trafficgraphwidget.h>
 #include <qt/clientmodel.h>
 
+#include <QPainterPath>
 #include <QPainter>
 #include <QColor>
 #include <QTimer>

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -26,6 +26,10 @@
 #include <QIcon>
 #include <QList>
 
+#include <boost/bind/placeholders.hpp>
+
+using namespace boost::placeholders;
+
 static int column_alignments[] = {
         Qt::AlignHCenter|Qt::AlignVCenter, /* # Confs */
         Qt::AlignLeft|Qt::AlignVCenter, /* date */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -36,6 +36,9 @@
 #include <QSet>
 #include <QTimer>
 
+#include <boost/bind/placeholders.hpp>
+
+using namespace boost::placeholders;
 
 WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, OptionsModel *_optionsModel, QObject *parent) :
     QObject(parent), wallet(_wallet), optionsModel(_optionsModel), addressTableModel(0),

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -51,6 +51,9 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind/placeholders.hpp>
+
+using namespace boost::placeholders;
 
 #if defined(NDEBUG)
 # error "Drivechain cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -16,8 +16,12 @@
 #include <list>
 #include <atomic>
 #include <future>
+#include <functional>
 
 #include <boost/signals2/signal.hpp>
+#include <boost/bind/placeholders.hpp>
+
+using namespace boost::placeholders;
 
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;


### PR DESCRIPTION
Without explicitly including boost/bind/placeholders.hpp and QPainterPath the build fails on my machine.